### PR TITLE
Use pathlib for git-graph python module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
 
 
 script:
-  - flake8
+  - python -m flake8
   - pytest -vv

--- a/git_graph/dot_graph.py
+++ b/git_graph/dot_graph.py
@@ -95,11 +95,11 @@ class DotGraph(graphviz.Digraph):
                     if e in node_set:
                         self.edge(c, e)
         if 'l' in nodes:
-            for l in git_graph.local_branches:
-                self.node(l, label=l[:SHORT], fillcolor="#9999ff")  # violet
-                e = git_graph.local_branches[l]
+            for br in git_graph.local_branches:
+                self.node(br, label=br[:SHORT], fillcolor="#9999ff")  # violet
+                e = git_graph.local_branches[br]
                 if e in node_set:
-                    self.edge(l, e)
+                    self.edge(br, e)
         if 'h' in nodes:
             h = git_graph.local_head[0]
             self.node(h, label=h[:SHORT], fillcolor="#e6ccff")  # pale violet

--- a/git_graph/dot_graph.py
+++ b/git_graph/dot_graph.py
@@ -147,7 +147,7 @@ class DotGraph(graphviz.Digraph):
 
     def persist(self, form=DEFAULT_FORMAT, conceal=True):
         self.format = form
-        git_graph_path = Path(self.git_path + '/.gitGraph')
+        git_graph_path = Path(str(self.git_path) + '/.gitGraph')
         if not git_graph_path.is_dir():
             git_graph_path.mkdir()
         dot_file_name = datetime.datetime.now().strftime(

--- a/git_graph/dot_graph.py
+++ b/git_graph/dot_graph.py
@@ -1,4 +1,5 @@
 import datetime
+from pathlib import Path
 
 import graphviz
 
@@ -146,7 +147,7 @@ class DotGraph(graphviz.Digraph):
 
     def persist(self, form=DEFAULT_FORMAT, conceal=True):
         self.format = form
-        git_graph_path = self.git_path / '.gitGraph'
+        git_graph_path = Path(self.git_path + '/.gitGraph')
         if not git_graph_path.is_dir():
             git_graph_path.mkdir()
         dot_file_name = datetime.datetime.now().strftime(

--- a/git_graph/git_functions.py
+++ b/git_graph/git_functions.py
@@ -7,7 +7,7 @@ tr = 'refs/tags/'
 
 
 def execute_git_command(path, command):
-    if not Path(path + '/.git').is_dir():
+    if not Path(str(path) + '/.git').is_dir():
         print('Not a git repository')
         return []
     bash_command = 'git -C ' + str(path) + ' ' + command

--- a/git_graph/git_functions.py
+++ b/git_graph/git_functions.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 lbr = 'refs/heads/'
 rbr = 'refs/remotes/'
@@ -6,7 +7,7 @@ tr = 'refs/tags/'
 
 
 def execute_git_command(path, command):
-    if not (path / '.git').is_dir():
+    if not Path(path + '/.git').is_dir():
         print('Not a git repository')
         return []
     bash_command = 'git -C ' + str(path) + ' ' + command


### PR DESCRIPTION
To run this package as a Python module will crash as explained in #3 

Since Python 3 it's a good practice to use Pathlib when needed.

This closes #3